### PR TITLE
Add UART printf to STM32 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # test
+
 Testing ChatGPT Codex
+
+## STM32F446 Hello World Example
+
+This repository includes a simple example for the STM32F446 using the STM32 LL libraries. The program prints `HEllo World` on USART2 and blinks the on-board LED (PA5). It demonstrates a minimal `printf` implementation that writes characters through USART2.
+
+Build with:
+
+```bash
+make -C stm32f446_hello
+```
+
+A cross compiler such as `arm-none-eabi-gcc` and the STM32F4 LL headers are required.
+

--- a/stm32f446_hello/Makefile
+++ b/stm32f446_hello/Makefile
@@ -1,0 +1,22 @@
+CC=arm-none-eabi-gcc
+CFLAGS=-mcpu=cortex-m4 -mthumb -O2 -g -Wall
+LDFLAGS=-Tstm32f446re.ld -nostartfiles -Wl,--gc-sections
+
+SRC=main.c startup_stm32f446xx.s
+OBJ=$(SRC:.c=.o)
+
+all: main.elf
+
+main.elf: $(OBJ)
+	$(CC) $(CFLAGS) $(OBJ) -o $@ $(LDFLAGS)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+%.o: %.s
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJ) main.elf
+
+.PHONY: all clean

--- a/stm32f446_hello/main.c
+++ b/stm32f446_hello/main.c
@@ -1,0 +1,108 @@
+#include "stm32f4xx.h"
+#include "stm32f4xx_ll_bus.h"
+#include "stm32f4xx_ll_gpio.h"
+#include "stm32f4xx_ll_usart.h"
+#include "stm32f4xx_ll_utils.h"
+#include "stm32f4xx_ll_rcc.h"
+#include <stdio.h>
+#include <stdarg.h>
+
+static void uart_send_char(char c)
+{
+    LL_USART_TransmitData8(USART2, c);
+    while (!LL_USART_IsActiveFlag_TXE(USART2));
+}
+
+int uart_printf(const char *fmt, ...)
+{
+    char buf[128];
+    va_list args;
+    va_start(args, fmt);
+    int len = vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    for (int i = 0; i < len; ++i) {
+        uart_send_char(buf[i]);
+    }
+    return len;
+}
+
+void SystemClock_Config(void);
+void UART2_Init(void);
+void LED_Init(void);
+
+int main(void)
+{
+    SystemClock_Config();
+    LED_Init();
+    UART2_Init();
+
+    while (1) {
+        uart_printf("HEllo World\r\n");
+        LL_GPIO_TogglePin(GPIOA, LL_GPIO_PIN_5);
+        LL_mDelay(1000);
+    }
+}
+
+void LED_Init(void)
+{
+    /* Enable GPIOA clock */
+    LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_GPIOA);
+
+    /* Configure PA5 as output (LED on Nucleo-F446) */
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_5, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinOutputType(GPIOA, LL_GPIO_PIN_5, LL_GPIO_OUTPUT_PUSHPULL);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_5, LL_GPIO_SPEED_FREQ_LOW);
+}
+
+void UART2_Init(void)
+{
+    /* Enable GPIOA and USART2 clocks */
+    LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_GPIOA);
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_USART2);
+
+    /* Configure PA2 (TX) and PA3 (RX) */
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_2, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetAFPin_0_7(GPIOA, LL_GPIO_PIN_2, LL_GPIO_AF_7);
+    LL_GPIO_SetPinMode(GPIOA, LL_GPIO_PIN_3, LL_GPIO_MODE_ALTERNATE);
+    LL_GPIO_SetAFPin_0_7(GPIOA, LL_GPIO_PIN_3, LL_GPIO_AF_7);
+
+    /* USART2 configuration */
+    LL_USART_SetTransferDirection(USART2, LL_USART_DIRECTION_TX_RX);
+    LL_USART_SetParity(USART2, LL_USART_PARITY_NONE);
+    LL_USART_SetDataWidth(USART2, LL_USART_DATAWIDTH_8B);
+    LL_USART_SetStopBitsLength(USART2, LL_USART_STOPBITS_1);
+    LL_USART_SetBaudRate(USART2, SystemCoreClock/2, LL_USART_OVERSAMPLING_16, 115200);
+
+    LL_USART_Enable(USART2);
+}
+
+void SystemClock_Config(void)
+{
+    /* Set flash latency */
+    LL_FLASH_SetLatency(LL_FLASH_LATENCY_3);
+
+    /* Enable HSE and wait */
+    LL_RCC_HSE_Enable();
+    while(LL_RCC_HSE_IsReady() != 1);
+
+    /* Configure PLL */
+    LL_RCC_PLL_ConfigDomain_SYS(LL_RCC_PLLSOURCE_HSE, 8, 336, 4);
+    LL_RCC_PLL_Enable();
+    while(LL_RCC_PLL_IsReady() != 1);
+
+    /* Set system clock source to PLL */
+    LL_RCC_SetSysClkSource(LL_RCC_SYS_CLKSOURCE_PLL);
+    while(LL_RCC_GetSysClkSource() != LL_RCC_SYS_CLKSOURCE_STATUS_PLL);
+
+    /* Set prescalers */
+    LL_RCC_SetAHBPrescaler(LL_RCC_SYSCLK_DIV_1);
+    LL_RCC_SetAPB1Prescaler(LL_RCC_APB1_DIV_2);
+    LL_RCC_SetAPB2Prescaler(LL_RCC_APB2_DIV_1);
+
+    /* Update SystemCoreClock */
+    LL_SetSystemCoreClock(84000000);
+
+    /* Configure systick to 1 ms */
+    LL_Init1msTick(SystemCoreClock);
+}
+

--- a/stm32f446_hello/startup_stm32f446xx.s
+++ b/stm32f446_hello/startup_stm32f446xx.s
@@ -1,0 +1,28 @@
+    .syntax unified
+    .cpu cortex-m4
+    .thumb
+
+    .section .isr_vector,"a",%progbits
+    .type g_pfnVectors, %object
+    .size g_pfnVectors, .-g_pfnVectors
+
+    .globl g_pfnVectors
+    g_pfnVectors:
+    .word _estack
+    .word Reset_Handler
+
+    .weak Reset_Handler
+    .type Reset_Handler, %function
+Reset_Handler:
+    bl SystemInit
+    bl main
+1:  b 1b
+
+    .size Reset_Handler, .-Reset_Handler
+
+    .section .stack
+_estack:
+    .space 0x400
+
+    .end
+

--- a/stm32f446_hello/stm32f446re.ld
+++ b/stm32f446_hello/stm32f446re.ld
@@ -1,0 +1,36 @@
+/* Minimal linker script for STM32F446RE */
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512K
+  RAM (rwx)  : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+SECTIONS
+{
+  .text :
+  {
+    KEEP(*(.isr_vector))
+    *(.text*)
+    *(.rodata*)
+    _etext = .;
+  } > FLASH
+
+  .data : AT (ADDR(.text) + SIZEOF(.text))
+  {
+    _sdata = .;
+    *(.data*)
+    _edata = .;
+  } > RAM
+
+  .bss :
+  {
+    _sbss = .;
+    *(.bss*)
+    *(COMMON)
+    _ebss = .;
+  } > RAM
+
+  . = ALIGN(4);
+  end = .;
+}
+


### PR DESCRIPTION
## Summary
- add `uart_printf` using `vsnprintf`
- update main loop to use new printf and print `HEllo World`
- mention printf in README

## Testing
- `make -C stm32f446_hello` *(fails: arm-none-eabi-gcc not found)*